### PR TITLE
Routing can not always resolve the correct route

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -76,7 +76,7 @@ class Request implements RequestInterface
 
         $userInfo = $this->parseUserInfo() ?? null;
 
-        $uri = (!empty($userInfo) ? '//' . $userInfo . '@' : '')
+        $uri = '//' . (!empty($userInfo) ? $userInfo . '@' : '')
             . $this->swooleRequest->header['host']
             . $this->getRequestTarget()
             ;


### PR DESCRIPTION
Routing can not always resolve the correct route because the URI thinks it only sees a path inside of the url.

For example: When I go to `http://localhost/ping` the following URI will be feed to the URI factory `localhost/ping`. The `parse_url` in PHP now thinks that there is only a `path`. 

I prefixed the URI with `//` as you already did when you have user information from the `Authorization` header.