### PR TITLE
Fixing return type of Request::getHeaders()

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -134,9 +134,12 @@ class Request implements RequestInterface
 
     public function getHeaders()
     {
-        return is_array($this->headers)
+        $headers = is_array($this->headers)
             ? $this->headers
             : $this->swooleRequest->header;
+        return array_map(function($value) {
+            return is_array($value) ? $value : [$value];
+        }, $headers);
     }
 
     public function hasHeader($name)

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -25,7 +25,7 @@ class ServerRequest extends Request implements ServerRequestInterface
 
     public function getServerParams()
     {
-        return $_SERVER ?? [];
+        return array_merge($_SERVER ?? [], $this->swooleRequest->server ?? []);
     }
 
     public function getCookieParams()

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -25,7 +25,7 @@ class ServerRequest extends Request implements ServerRequestInterface
 
     public function getServerParams()
     {
-        return array_merge($_SERVER ?? [], $this->swooleRequest->server ?? []);
+        return array_merge($_SERVER ?? [], array_change_key_case($this->swooleRequest->server ?? [], CASE_UPPER));
     }
 
     public function getCookieParams()


### PR DESCRIPTION
This pull request consists of two distinct changes:

1. [OpenSwoole](https://openswoole.com/docs/modules/swoole-http-request-header) seems to use a type like `array<string, string>` for the headers (just tested and verified that), but [PSR-7](https://www.php-fig.org/psr/psr-7/#31-psrhttpmessagemessageinterface) requires the type `array<string, list<string>>`. The `Request::getHeaders()` method returned the original OpenSwoole format. I changed that to the PSR-7 format.

2. `ServerRequest::getServerParams()` returned `$_SERVER` and ignored `$swooleRequest->server` (which contains request dependent values like the client IP address and port). I changed that such that `$_SERVER` and `$swooleRequest->server` are merged. The OpenSwoole parameters are prioritized and might overwrite the ones in `$_SERVER`. To make both list of parameters compatible all the parameter names are changed to be upper case.