### PR TITLE
"getUploadedFiles" estava retornando o " $this->files" quando não existia upload. ajeitado foreach de "$this->swooleRequest->files as $name => $fileData" para "$this->swooleRequest->files ?? [] as $name => $fileData"

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -54,23 +54,21 @@ class ServerRequest extends Request implements ServerRequestInterface
 
     public function getUploadedFiles()
     {
-        if (isset($this->files)) {
-            return $this->files;
+        if (!isset($this->files)) {
+            $this->files = [];
+
+            foreach ($this->swooleRequest->files ?? [] as $name => $fileData) {
+                $this->files[$name] = $this->uploadedFileFactory->createUploadedFile(
+                    $this->streamFactory->createStreamFromFile($fileData['tmp_name']),
+                    $fileData['size'],
+                    $fileData['error'],
+                    $fileData['name'],
+                    $fileData['type']
+                );
+            }
         }
 
-        $files = [];
-
-        foreach ($this->swooleRequest->files as $name => $fileData) {
-            $files[$name] = $this->uploadedFileFactory->createUploadedFile(
-                $this->streamFactory->createStreamFromFile($fileData['tmp_name']),
-                $fileData['size'],
-                $fileData['error'],
-                $fileData['name'],
-                $fileData['type']
-            );
-        }
-
-        return $files;
+        return $this->files;
     }
 
     public function withUploadedFiles(array $uploadedFiles)


### PR DESCRIPTION
"getUploadedFiles" estava retornando o " $this->files" quando não existia upload. ajeitado foreach de "$this->swooleRequest->files as $name => $fileData" para "$this->swooleRequest->files ?? [] as $name => $fileData"