### PR TITLE
fix error: Warning: foreach() argument must be of type array|object, …

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -60,7 +60,8 @@ class ServerRequest extends Request implements ServerRequestInterface
 
         $files = [];
 
-        foreach ($this->swooleRequest->files ?? [] as $name => $fileData) {
+        $swooleFiles = $this->swooleRequest->files ?? [];
+        foreach ($swooleFiles as $name => $fileData) {
             $files[$name] = $this->uploadedFileFactory->createUploadedFile(
                 $this->streamFactory->createStreamFromFile($fileData['tmp_name']),
                 $fileData['size'],


### PR DESCRIPTION
Warning: foreach() argument must be of type array|object, null given in /public/project/vendor/imefisto/psr-swoole-native/src/ServerRequest.php on line 63